### PR TITLE
Add LRU cache ersion of user_agent_parser.Parse

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -184,7 +184,7 @@ setup(
     url='https://github.com/ua-parser/uap-python',
     include_package_data=True,
     setup_requires=['pyyaml'],
-    install_requires=[],
+    install_requires=['backports.functools_lru_cache'],
     cmdclass=cmdclass,
     classifiers=[
         'Development Status :: 4 - Beta',

--- a/tox.ini
+++ b/tox.ini
@@ -4,6 +4,7 @@ envlist = py26, py27, pypy, py31, py32, py33, py34, py35, docs, py27-flake8, py3
 [testenv]
 deps =
     pyyaml
+    mock
 commands =
     python setup.py develop
     python ua_parser/user_agent_parser_test.py


### PR DESCRIPTION
When looping over 100000 real agent strings collected from production
traffic the time required dropped from 100 seconds to 27 seconds and uses less
then a MB of memory.

In order to preserve the previous behavior, there is a new function
ParseLRU.

This adds mock as a test dependency and backports.functools_lru_cache as
a runtime dependency